### PR TITLE
chore: add repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "connection",
     "resource"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/libp2p/js-libp2p-connection-manager.git"
+  },
   "license": "MIT",
   "pre-push": [
     "lint"


### PR DESCRIPTION
The package.json for this module contains no repo field so there's no way to track back to gh from the npm page.